### PR TITLE
STONK-18: Docs > Automatically Add Labels For Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,14 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "frontend"
 
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "backend"


### PR DESCRIPTION
## Ticket

Closes #29 

## Changes

- automatically label dependabot PRs with `frontend` or `backend`

## Developer Checklist

- [x] I have verified my changes to confirm that it works
- [x] I have added the appropriate label to this pull request
- [x] I have linked the corresponding issue to this pull request
- [x] I have followed the pull request title pattern of `STONK-NUMBER: Domain > Issue Title`
